### PR TITLE
added error handling for stripe returning deleted customer object

### DIFF
--- a/app/models/concerns/billable.rb
+++ b/app/models/concerns/billable.rb
@@ -27,11 +27,12 @@ module Billable
     end
   end
 
-  def stripe_customer
-    Stripe::Customer.retrieve({
-      id: stripe_customer_id,
-      expand: ['subscriptions']
-    })
+  def stripe_customer_valid?
+    Stripe::Customer.retrieve(self.stripe_customer_id)
+
+  rescue Stripe::InvalidRequestError => e
+    Rails.logger.error("Stripe error: #{e.message}")
+    false
   end
 
   def create_stripe_customer
@@ -44,7 +45,7 @@ module Billable
       }
     })
     Rails.logger.info("Stripe customer created: #{customer.id}")
-    update(stripe_customer_id: customer.id)
+    self.update(stripe_customer_id: customer.id)
   end
 
   # done after user adds payment method, for easy CVR metrics inside database


### PR DESCRIPTION
a deleted customer was still returning a customer object and not being recognised as invalid, therefore not creating a new customer instance.  This fix looks for the deleted key, and if true a new stripe customer is created and saved to the company.stripe_customer_id.